### PR TITLE
Merge rooms and skins

### DIFF
--- a/backend/models/record.py
+++ b/backend/models/record.py
@@ -64,9 +64,7 @@ class Record(db.Model):
     def set_not_current(cls, type_str, type_id):
         """Set record's current state to False in the DB."""
 
-        # check if this is already in the db as the current
         existing = Record.query.filter_by(type=type_str, type_id=type_id, current=True).first()
-
         existing.current = False
         db.session.commit()
 

--- a/backend/models/record.py
+++ b/backend/models/record.py
@@ -59,3 +59,24 @@ class Record(db.Model):
 
         db.session.add(new_record)
         db.session.commit()
+
+    @classmethod
+    def set_not_current(cls, type_str, type_id):
+        """Set record's current state to False in the DB."""
+
+        # check if this is already in the db as the current
+        existing = Record.query.filter_by(type=type_str, type_id=type_id, current=True).first()
+
+        existing.current = False
+        db.session.commit()
+
+    @classmethod
+    def purge_old_records(cls, type_str, still_presents_ids):
+        """Disable old records not presents in API."""
+
+        current_ids = Record.query.filter_by(type=type_str, current=True).with_entities(Record.type_id).all()
+        current_ids = [current_id[0] for current_id in current_ids]
+        no_more_presents_ids = list(set(current_ids) - set(still_presents_ids))
+
+        for no_more_presents_id in no_more_presents_ids:
+            Record.set_not_current(type_str, no_more_presents_id)

--- a/backend/pixyship.py
+++ b/backend/pixyship.py
@@ -411,25 +411,14 @@ class PixyShip(metaclass=Singleton):
         """Update data and save records."""
 
         sprites = self.pixel_starships_api.get_sprites()
+        still_presents_ids = []
 
         for sprite in sprites:
             record_id = sprite['SpriteId']
             Record.update_data('sprite', record_id, sprite['pixyship_xml_element'])
+            still_presents_ids.append(int(record_id))
 
-    def _get_room_sprites_from_api(self):
-        """Get room sprites from API."""
-
-        rooms_sprites = self.pixel_starships_api.get_rooms_sprites()
-
-        return {
-            int(room_sprite['RoomDesignSpriteId']): {
-                'room_id': int(room_sprite['RoomDesignId']),
-                'race': int(room_sprite['RaceId']),
-                'sprite_id': int(room_sprite['SpriteId']),
-                'type': room_sprite['RoomSpriteType'],
-            }
-            for room_sprite in rooms_sprites
-        }
+        Record.purge_old_records('sprite', still_presents_ids)
 
     def _get_room_sprites_from_db(self):
         """Load sprites from database."""
@@ -445,6 +434,10 @@ class PixyShip(metaclass=Singleton):
                 'race': int(room_sprite['RaceId']),
                 'sprite_id': int(room_sprite['SpriteId']),
                 'type': room_sprite['RoomSpriteType'],
+                'skin_name': room_sprite['SkinName'],
+                'skin_key': int(room_sprite['SkinKey']),
+                'skin_description': room_sprite['SkinDescription'],
+                'requirement': self._parse_requirement(room_sprite['RequirementString']),
             }
 
         return room_sprites
@@ -453,10 +446,14 @@ class PixyShip(metaclass=Singleton):
         """Update data and save records."""
 
         room_sprites = self.pixel_starships_api.get_rooms_sprites()
+        still_presents_ids = []
 
         for room_sprite in room_sprites:
             record_id = room_sprite['RoomDesignSpriteId']
             Record.update_data('room_sprite', record_id, room_sprite['pixyship_xml_element'])
+            still_presents_ids.append(int(record_id))
+
+        Record.purge_old_records('room_sprite', still_presents_ids)
 
     def _get_trainings_from_db(self):
         """Load trainings from database."""
@@ -490,10 +487,14 @@ class PixyShip(metaclass=Singleton):
         """Update data and save records."""
 
         trainings = self.pixel_starships_api.get_trainings()
+        still_presents_ids = []
 
         for training in trainings:
             record_id = int(training['TrainingDesignId'])
             Record.update_data('training', record_id, training['pixyship_xml_element'])
+            still_presents_ids.append(int(record_id))
+
+        Record.purge_old_records('training', still_presents_ids)
 
     def _get_achievements_from_db(self):
         """Load achievements from database."""
@@ -545,10 +546,14 @@ class PixyShip(metaclass=Singleton):
         """Update data and save records."""
 
         achievements = self.pixel_starships_api.get_achievements()
+        still_presents_ids = []
 
         for achievement in achievements:
             record_id = int(achievement['AchievementDesignId'])
             Record.update_data('achievement', record_id, achievement['pixyship_xml_element'])
+            still_presents_ids.append(int(record_id))
+
+        Record.purge_old_records('achievement', still_presents_ids)
 
     @staticmethod
     def _get_prices_from_db():
@@ -655,10 +660,14 @@ class PixyShip(metaclass=Singleton):
         """Get ships from API and save them in database."""
 
         ships = self.pixel_starships_api.get_ships()
+        still_presents_ids = []
 
         for ship in ships:
             record_id = ship['ShipDesignId']
             Record.update_data('ship', record_id, ship['pixyship_xml_element'])
+            still_presents_ids.append(int(record_id))
+
+        Record.purge_old_records('ship', still_presents_ids)
 
     def _get_ships_from_db(self):
         """Load ships from database."""
@@ -704,10 +713,14 @@ class PixyShip(metaclass=Singleton):
         """Update data and save records."""
 
         researches = self.pixel_starships_api.get_researches()
+        still_presents_ids = []
 
         for research in researches:
             record_id = research['ResearchDesignId']
             Record.update_data('research', record_id, research['pixyship_xml_element'])
+            still_presents_ids.append(int(record_id))
+
+        Record.purge_old_records('research', still_presents_ids)
 
     def _get_researches_from_db(self):
         """Load researches from database."""
@@ -755,10 +768,14 @@ class PixyShip(metaclass=Singleton):
         """Get rooms from API and save them in database."""
 
         rooms = self.pixel_starships_api.get_rooms()
+        still_presents_ids = []
 
         for room in rooms:
             record_id = room['RoomDesignId']
             Record.update_data('room', record_id, room['pixyship_xml_element'], ['AvailabilityMask'])
+            still_presents_ids.append(int(record_id))
+
+        Record.purge_old_records('room', still_presents_ids)
 
     def _get_rooms_from_db(self):
         """Load rooms from database."""
@@ -851,10 +868,14 @@ class PixyShip(metaclass=Singleton):
         """Get crews from API and save them in database."""
 
         characters = self.pixel_starships_api.get_characters()
+        still_presents_ids = []
 
         for character in characters:
             record_id = character['CharacterDesignId']
             Record.update_data('char', record_id, character['pixyship_xml_element'])
+            still_presents_ids.append(int(record_id))
+
+        Record.purge_old_records('char', still_presents_ids)
 
     def _get_characters_from_db(self):
         """Load crews from database."""
@@ -913,10 +934,14 @@ class PixyShip(metaclass=Singleton):
         """Get collections from API and save them in database."""
 
         collections = self.pixel_starships_api.get_collections()
+        still_presents_ids = []
 
         for collection in collections:
             record_id = collection['CollectionDesignId']
             Record.update_data('collection', record_id, collection['pixyship_xml_element'])
+            still_presents_ids.append(int(record_id))
+
+        Record.purge_old_records('collection', still_presents_ids)
 
     def _get_collections_from_db(self):
         """Load collections from database."""
@@ -1080,10 +1105,14 @@ class PixyShip(metaclass=Singleton):
         """Get items from API and save them in database."""
 
         items = self.pixel_starships_api.get_items()
+        still_presents_ids = []
 
         for item in items:
             record_id = item['ItemDesignId']
             Record.update_data('item', record_id, item['pixyship_xml_element'], ['FairPrice', 'MarketPrice'])
+            still_presents_ids.append(int(record_id))
+
+        Record.purge_old_records('item', still_presents_ids)
 
     def _get_items_from_db(self):
         """Get items from database."""
@@ -2039,3 +2068,27 @@ class PixyShip(metaclass=Singleton):
                     upgrades.append(PixyShip._create_light_item(item))
 
         return upgrades
+
+    def merge_rooms_and_sprites(self, rooms, rooms_sprites):
+        merged_rooms = rooms
+
+        # merge only RoomSprite with a SkinName
+        filtered_rooms_sprites = {}
+        for room_sprite_id, room_sprite in rooms_sprites.items():
+            if room_sprite['skin_name'] and room_sprite['type'] == 'Interior':
+                filtered_rooms_sprites[room_sprite_id] = room_sprite
+
+        index = -1
+        for room_sprite_id, room_sprite in filtered_rooms_sprites.items():
+            new_room = rooms[room_sprite['room_id']].copy()
+            new_room['name'] = room_sprite['skin_name']
+            new_room['description'] = room_sprite['skin_description']
+            new_room['sprite'] = self.get_sprite_infos(room_sprite['sprite_id'])
+            new_room['requirement'] = room_sprite['requirement']
+
+            # TODO: better id (used by front to sort rooms by oldest)
+            new_room['id'] = index
+            merged_rooms[index] = new_room
+            index -= 1
+
+        return merged_rooms

--- a/backend/pixyship.py
+++ b/backend/pixyship.py
@@ -840,6 +840,7 @@ class PixyShip(metaclass=Singleton):
                 'emp_length': float(missile_design['EMPLength']) if missile_design else 0,
                 'stun_length': float(missile_design['StunLength']) if missile_design else 0,
                 'hull_percentage_damage': float(missile_design['HullPercentageDamage']) if missile_design else 0,
+                'skin': False,
             }
 
         upgrades = {
@@ -2085,6 +2086,7 @@ class PixyShip(metaclass=Singleton):
             new_room['description'] = room_sprite['skin_description']
             new_room['sprite'] = self.get_sprite_infos(room_sprite['sprite_id'])
             new_room['requirement'] = room_sprite['requirement']
+            new_room['skin'] = True
 
             # TODO: better id (used by front to sort rooms by oldest)
             new_room['id'] = index

--- a/backend/run.py
+++ b/backend/run.py
@@ -234,8 +234,12 @@ def api_tournament():
 @app.route('/api/rooms')
 @enforce_source
 def api_rooms():
+    rooms = pixyship.rooms
+    rooms_sprites = pixyship.rooms_sprites
+    data = pixyship.merge_rooms_and_sprites(rooms, rooms_sprites)
+
     return jsonify({
-        'data': pixyship.rooms,
+        'data': data,
         'status': 'success',
     })
 

--- a/backend/test/test_api.py
+++ b/backend/test/test_api.py
@@ -213,6 +213,23 @@ def test_rooms():
     assert 'AvailabilityMask' in room_with_purchase
 
 
+def test_rooms_sprites():
+    pixel_starships_api = PixelStarshipsApi()
+    rooms_sprites = pixel_starships_api.get_rooms_sprites()
+
+    assert len(rooms_sprites) > 0
+
+    room_sprite = rooms_sprites[0]
+    assert 'RoomDesignId' in room_sprite
+    assert 'RaceId' in room_sprite
+    assert 'SpriteId' in room_sprite
+    assert 'RoomSpriteType' in room_sprite
+    assert 'SkinName' in room_sprite
+    assert 'SkinDescription' in room_sprite
+    assert 'SkinKey' in room_sprite
+    assert 'RequirementString' in room_sprite
+
+
 def test_characters():
     pixel_starships_api = PixelStarshipsApi()
     characters = pixel_starships_api.get_characters()

--- a/frontend/src/views/Rooms.vue
+++ b/frontend/src/views/Rooms.vue
@@ -6,7 +6,7 @@
     <!-- Filters -->
     <v-card-subtitle v-if="loaded">
       <v-row>
-        <v-col cols="12" sm="12" md="4">
+        <v-col cols="12" sm="12" md="2">
           <v-text-field
             v-model="searchName"
             append-icon="mdi-magnify"
@@ -68,6 +68,18 @@
             :value-comparator="filterValueComparator"
           ></v-autocomplete>
         </v-col>
+        <v-col cols="12" sm="6" md="2">
+          <v-autocomplete
+            v-model="searchSkin"
+            :items="skins"
+            label="Skin"
+            clearable
+            outlined
+            small-chips
+            hide-details
+            :value-comparator="filterValueComparator"
+          ></v-autocomplete>
+        </v-col>
       </v-row>
     </v-card-subtitle>
 
@@ -111,6 +123,10 @@
                 <div :class="[item.rarity, 'lh-9', 'name']">
                   <span>{{ item.short_name }}</span>
                 </div>
+              </td>
+
+              <td>
+                {{ item.skin }}
               </td>
 
               <td>{{ item.type }}</td>
@@ -380,10 +396,12 @@ export default {
       searchShipLevel: [],
       searchSize: [],
       searchType: [],
+      searchSkin: null,
       levels: [],
       shipLevels: [],
       types: [],
       sizes: [],
+      skins: [],
       loaded: false,
       rooms: [],
       headers: [
@@ -418,6 +436,19 @@ export default {
           align: "left", 
           value: "short_name",
           filterable: true
+        },
+        { 
+          text: "Skin", 
+          align: "left", 
+          value: "skin",
+          filterable: true,
+          filter: (value) => {
+            if (this.searchSkin !== null) {
+              return value === this.searchSkin
+            }
+
+            return true
+          },
         },
         {
           text: "Type",
@@ -493,6 +524,7 @@ export default {
         || this.searchShipLevel.length > 0
         || this.searchSize.length > 0
         || this.searchType.length > 0
+        || this.searchSkin.length > 0
     }
   },
 
@@ -553,6 +585,10 @@ export default {
       this.updateQueryFromFilter('type', value)
     },
 
+    searchSkin(value) {
+      this.updateQueryFromFilter('skin', value)
+    },
+
     searchLevel(value) {
       this.updateQueryFromFilter('level', value)
     },
@@ -593,6 +629,12 @@ export default {
           return value.trim()
         })
       }
+
+      if (this.$route.query.skin) {
+        this.searchSkin = this.$route.query.skin.split(',').map(function(value) {
+          return value.trim()
+        })
+      }
     },
 
     computeDps(damage, room) {
@@ -624,6 +666,7 @@ export default {
           room.upgrade_cost = 0
         }
 
+        room.skin = room.skin ? 'Yes' : 'No'
         rooms.push(room)
       }
 
@@ -655,6 +698,10 @@ export default {
 
       this.types = Array.from(
         new Set(this.rooms.map((room) => (!room.type ? "None" : room.type)))
+      ).sort(this.sortAlphabeticallyExceptNone)
+
+      this.skins = Array.from(
+        new Set(this.rooms.map((room) => (room.skin)))
       ).sort(this.sortAlphabeticallyExceptNone)
     },
 


### PR DESCRIPTION
Since last PSS patch, skins are not regular rooms but dedicated sprites. I don't want to create a new "Skins" section in PixyShip for now, so I merge skins in the "Rooms" page.